### PR TITLE
Save built docs artefact

### DIFF
--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -96,8 +96,5 @@ jobs:
 
   - publish: docs/_build/
     artifact: docs
-    inputs:
-      pathToPublish: docs/_build/
-      artifactName: docs
     condition: eq(variables.TOXENV, 'docs')
     displayName: publish docs artifact

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,8 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - task: PublishBuildArtifacts@1
+  - publish: docs/_build/
+    artifact: docs
     inputs:
       pathToPublish: docs/_build/
       artifactName: docs

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,7 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - ${{ if eq(variables.env, "docs") }}:
+  - ${{ if eq(variables.env, 'docs') }}:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: docs/_build/

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,9 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - publish: docs/_build/
-    artifact: docs
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: docs/_build/
+      artifactName: docs
     condition: eq(variables.TOXENV, 'docs')
     displayName: publish docs artifact

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -93,3 +93,10 @@ jobs:
         pathToPublish: wheels
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
+
+  - ${{ if eq(env, "docs") }}:
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: docs/_build/
+        artifactName: docs
+      displayName: publish docs artifact

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,7 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - ${{ if eq(env, "docs") }}:
+  - ${{ if eq(TOXENV, "docs") }}:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: docs/_build/

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,9 +94,9 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - ${{ if eq(variables.env, 'docs') }}:
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathToPublish: docs/_build/
-        artifactName: docs
-      displayName: publish docs artifact
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: docs/_build/
+      artifactName: docs
+    condition: eq(variables.TOXENV, 'docs')
+    displayName: publish docs artifact

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,7 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - ${{ if eq($(TOXENV), "docs") }}:
+  - ${{ if eq(variables.env, "docs") }}:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: docs/_build/

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -94,7 +94,7 @@ jobs:
         artifactName: wheel_${{ parameters.os }}_$(TOXENV)${{ parameters.name_postfix }}
       displayName: publish wheel artifact
 
-  - ${{ if eq(TOXENV, "docs") }}:
+  - ${{ if eq($(TOXENV), "docs") }}:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: docs/_build/

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,8 @@ envlist = py27,py35,py36,py37,py38,pypy,pypy3,docs
 
 [testenv]
 commands = python --version --version
+
+[testenv:docs]
+commands =
+    mkdir -p docs/_build
+    echo "spam" > docs/_build/eggs.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands = python --version --version
 [testenv:docs]
 whitelist_externals =
     mkdir
-    echo
+    sh
 commands =
     mkdir -p docs/_build
     sh -c 'echo "spam" > docs/_build/eggs.txt'

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ whitelist_externals =
     echo
 commands =
     mkdir -p docs/_build
-    echo "spam" > docs/_build/eggs.txt
+    sh -c 'echo "spam" > docs/_build/eggs.txt'

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist = py27,py35,py36,py37,py38,pypy,pypy3,docs
 commands = python --version --version
 
 [testenv:docs]
+whitelist_externals =
+    mkdir
+    echo
 commands =
     mkdir -p docs/_build
     echo "spam" > docs/_build/eggs.txt


### PR DESCRIPTION
If a `docs` job was run, save the built docs as an artefact. This helps maintainers see the result of a documentation change.

Note this conforms to the test-suite defined in `azure-pipelines.yml`.

PS: You may want to squash commits. Also, you're welcome to remove the changes to `tox.ini` if you'd like.